### PR TITLE
Fixes a bug in SimulraHSB2

### DIFF
--- a/colormaps/src/main/java/de/fhg/igd/iva/colormaps/impl/SimulaHSB2.java
+++ b/colormaps/src/main/java/de/fhg/igd/iva/colormaps/impl/SimulaHSB2.java
@@ -25,7 +25,8 @@ public class SimulaHSB2 extends AbstractKnownColormap {
 		double ny = (float) (y * 2 - 1);
 		double dist = max(abs(ny), abs(nx));
 		double ang = Math.atan2(ny, nx);
-		double[] rgb = HSI.hsi2rgb(new double[] {ang, 1, dist});
+		double hue = ang * 3.0 / Math.PI;
+		double[] rgb = HSI.hsi2rgb(new double[] {hue, 1, dist});
 		return new Color((float)rgb[0], (float)rgb[1], (float)rgb[2]);
 	}
 


### PR DESCRIPTION

![SimulaHSB2_bug_fix](https://github.com/user-attachments/assets/bfd351e3-c6a0-4a99-b4bd-5de33badb31a)
The HSI.hsi2rgb() function expects the hue value in the range [0,6) rather than radians. Therefore, the result of atan2() needs to be adjusted to fit within this range.
